### PR TITLE
change build requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,6 @@ build:
 python:
   # Install our python package before building the docs
   install:
-    - method: pip
-      path: .
     - requirements: docs/requirements.txt
    
 sphinx:


### PR DESCRIPTION
### Linked issues
None

### Summarize your change.
Fix readthedocs build fails

### Describe the reason for the change.
ReadTheDocs builds are failing on the main Open RV repo. The reason was the the build would try to run `pip` as specified in `.readthedocs.yaml`. The inclusion of pip was a mistake.

### Describe what you have tested and on which operating system.
Built successfully in OpenRV fork.

### Add a list of changes, and note any that might need special attention during the review.
Edited: `.readthedocs.yaml`: removed the pip requirements and its associated build dir.